### PR TITLE
Use project and change database materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Basic `profile.yml` for connecting to MindsDB:
 mindsdb:
   outputs:
     dev:
-      database: 'mindsdb'
       host: '127.0.0.1'
       password: ''
       port: 47335
-      schema: 'mindsdb'
+      database: 'mindsdb'
+      project: 'my_project'
+      # schema: 'my_project'
       type: mindsdb
       username: 'mindsdb'
   target: dev
@@ -29,12 +30,12 @@ mindsdb:
 ```
 | Key      | Required | Description                                          | Example                        |
 | -------- | -------- | ---------------------------------------------------- | ------------------------------ |
-| type     |    ✔️   | The specific adapter to use                          | `mindsdb`                      |
-| host     |    ✔️   | The MindsDB (hostname) to connect to                 | `cloud.mindsdb.com`            |
-| port     |    ✔️   | The port to use                                      | `3306`  or `47335`             |
-| schema   |    ✔️   | Specify the schema (database) to build models into   | The MindsDB datasource         |
-| username |    ✔️   | The username to use to connect to the server         | `mindsdb` or mindsdb cloud user|
-| password |    ✔️   | The password to use for authenticating to the server | `pass                          |
+| type     |    ✔️   | The specific adapter to use                            | `mindsdb`                      |
+| host     |    ✔️   | The MindsDB (hostname) to connect to                   | `cloud.mindsdb.com`            |
+| port     |    ✔️   | The port to use                                        | `3306`  or `47335`             |
+| schema   |    ✔️   | Specify the schema (project) to build models into      | The MindsDB datasource         |
+| username |    ✔️   | The username to use to connect to the server           | `mindsdb` or mindsdb cloud user|
+| password |    ✔️   | The password to use for authenticating to the server   | `pass                          |
 
 ## Usage
 
@@ -42,11 +43,11 @@ mindsdb:
 ```    
     dbt init <project_name>
 ```
-- create a intergration with "database" materialization:
+- create a integration with "integration" materialization:
 ```
     {{
     config(
-      materialized='database',
+      materialized='integration',
       engine='trino',
       parameters={
         "user": env_var('TRINO_USER'),
@@ -103,7 +104,7 @@ Parameters:
     In has to be created in mindsdb beforehand
 ```    
     {{ config(materialized='table', integration='int1') }}
-        select a, bc from ddd JOIN TEST_PREDICTOR_NAME where name > latest
+        select a, bc from ddd JOIN TEST_PREDICTOR_NAME where name > LATEST
 ```
 Notes: predictor_name has been removed. Instead it must be set explicitly in JOIN part of the model
 

--- a/dbt/adapters/mindsdb/__init__.py
+++ b/dbt/adapters/mindsdb/__init__.py
@@ -1,8 +1,10 @@
+from dbt.adapters.base import AdapterPlugin
+
 from dbt.adapters.mindsdb.connections import MindsdbConnectionManager
 from dbt.adapters.mindsdb.connections import MindsdbCredentials
-from dbt.adapters.mindsdb.impl import MindsdbAdapter
+from dbt.adapters.mindsdb.relation import MindsdbRelation
 
-from dbt.adapters.base import AdapterPlugin
+from dbt.adapters.mindsdb.impl import MindsdbAdapter
 from dbt.include import mindsdb
 
 

--- a/dbt/adapters/mindsdb/__version__.py
+++ b/dbt/adapters/mindsdb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.0.1"
+version = "1.0.3"

--- a/dbt/adapters/mindsdb/connections.py
+++ b/dbt/adapters/mindsdb/connections.py
@@ -12,6 +12,7 @@ import mysql.connector
 
 @dataclass
 class MindsdbCredentials(Credentials):
+    _ALIASES = {"project": "schema"}
     host: str
     port: int
     username: str

--- a/dbt/adapters/mindsdb/impl.py
+++ b/dbt/adapters/mindsdb/impl.py
@@ -1,11 +1,11 @@
 from dbt.adapters.sql import SQLAdapter
-from dbt.adapters.mindsdb import MindsdbConnectionManager
-
+from dbt.adapters.mindsdb import MindsdbConnectionManager, MindsdbRelation
 
 LIST_SCHEMAS_MACRO_NAME = 'list_schemas'
 LIST_RELATIONS_MACRO_NAME = 'list_relations_without_caching'
 
 class MindsdbAdapter(SQLAdapter):
+    Relation = MindsdbRelation
     ConnectionManager = MindsdbConnectionManager
 
     @classmethod

--- a/dbt/adapters/mindsdb/relation.py
+++ b/dbt/adapters/mindsdb/relation.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass,field
 
 from dbt.adapters.base.relation import BaseRelation, Policy
 from dbt.contracts.relation import ComponentName
@@ -13,7 +13,7 @@ class MindsdbQuotePolicy(Policy):
 
 @dataclass(frozen=True, eq=False, repr=False)
 class MindsdbRelation(BaseRelation):
-    quote_policy: MindsdbQuotePolicy = MindsdbQuotePolicy()
+    quote_policy: MindsdbQuotePolicy = field(default_factory=lambda: MindsdbQuotePolicy())
 
     # Overridden as Mindsdb converts relation identifiers to lowercase
     def _is_exactish_match(self, field: ComponentName, value: str) -> bool:

--- a/dbt/include/mindsdb/macros/adapters.sql
+++ b/dbt/include/mindsdb/macros/adapters.sql
@@ -31,15 +31,22 @@
 {% endmacro %}
 
 
-{% macro drop_predictor_wrap(predictor) -%}
-
-    DROP PREDICTOR IF EXISTS {{ predictor }};
+{% macro drop_predictor_wrap(project, predictor) -%}
+    {% if project is none %} 
+    DROP PREDICTOR IF EXISTS mindsdb.{{ predictor }};
+    {% else %}
+    DROP PREDICTOR IF EXISTS {{ project }}.{{ predictor }};
+    {% endif %}
 
 {% endmacro %}
 
-{% macro create_predictor_wrap(sql, predictor, integration, predict, predict_alias, using, order_by, group_by, window, horizon) -%}
+{% macro create_predictor_wrap(sql, project, predictor, integration, predict, predict_alias, using, order_by, group_by, window, horizon) -%}
 
-    CREATE PREDICTOR {{ predictor }}
+    {% if project is none %} 
+    CREATE PREDICTOR mindsdb.{{ predictor }}
+    {% else %}
+    CREATE PREDICTOR {{ project }}.{{ predictor }}
+    {% endif %}
     {%- if integration is not none %}
     FROM {{ integration }}  (
         {{ sql }}

--- a/dbt/include/mindsdb/macros/materialization/integration.sql
+++ b/dbt/include/mindsdb/macros/materialization/integration.sql
@@ -1,4 +1,4 @@
-{% materialization database, adapter='mindsdb' %}
+{% materialization integration, adapter='mindsdb' %}
   {%- set database = model['alias'] -%}
   {%- set engine = config.get('engine') -%}
   {%- set prefix = config.get('prefix') -%}

--- a/dbt/include/mindsdb/macros/materialization/predictor.sql
+++ b/dbt/include/mindsdb/macros/materialization/predictor.sql
@@ -1,6 +1,7 @@
 
 {% materialization predictor, adapter='mindsdb' %}
 
+  {%- set project = model.schema -%}
   {%- set predictor = model['alias'] -%}
   {%- set integration = config.get('integration') -%}
   {%- set predict = config.get('predict') -%}
@@ -34,14 +35,16 @@
 
 
   -- build model
+  -- even if project does not exists, mindsdb returns no error
   {%- call statement('main') -%}
-    {{ drop_predictor_wrap(predictor)}}
+    {{ drop_predictor_wrap(project, predictor)}}
   {%- endcall -%}
 
 
   {%- call statement('main') -%}
     {{ create_predictor_wrap(
                              sql,
+                             project,
                              predictor,
                              integration,
                              predict,

--- a/dbt/include/mindsdb/macros/materialization/table.sql
+++ b/dbt/include/mindsdb/macros/materialization/table.sql
@@ -17,10 +17,13 @@
   {%- endfor %}
 
   -- final
-  {% set target_relation = target_relation_list | join('.') %}
+  {%- set target_relation = api.Relation.create(identifier=target_relation_list[1],
+                                                schema=target_relation_list[0],
+                                                type='table') -%}
 
   -- ... setup database ...
   -- ... run pre-hooks...
+  {{ run_hooks(pre_hooks) }}
 
   -- build model
   {% call statement('main') %}
@@ -28,10 +31,10 @@
   {% endcall %}
 
   -- ... run post-hooks ...
+  {{ run_hooks(post_hooks) }}
   -- ... clean up the database...
 
   -- Return the relations created in this materialization
-
-  {{ return({'relations': []}) }}
+  {{ return({'relations': [target_relation]}) }}
 
 {%- endmaterialization -%}

--- a/dbt/include/mindsdb/macros/schema.sql
+++ b/dbt/include/mindsdb/macros/schema.sql
@@ -1,12 +1,29 @@
 {% macro mindsdb__create_schema(relation) -%}
-  {%- call statement('create_schema') -%}
-  SELECT 1
-  {% endcall %}
+
+  -- WA for https://github.com/mindsdb/mindsdb/issues/4152
+  {%- call statement('tables', fetch_result = True) -%}
+  SHOW DATABASES
+  {%- endcall -%}
+  {%- set tables = load_result('tables') -%}
+  {%- set tables_data = tables['data'] -%}
+
+  {%- set found_table = {'result':False} -%}
+  {% for item in tables_data %}
+    {% if item[0] == relation.schema %}
+      {% do found_table.update({'result': True}) %}
+    {% endif %}
+  {% endfor %}
+  {% if not found_table['result'] %}
+    {%- call statement('create_schema') -%}
+      CREATE PROJECT {{ relation.schema }}
+    {%- endcall -%}
+  {% endif %}
+  -- end WA
 {% endmacro %}
 
 
 {% macro mindsdb__drop_schema(relation) -%}
   {%- call statement('drop_schema') -%}
-    drop database if exists {{ relation.without_identifier() }}
+    drop database if exists {{ relation.project }}
   {% endcall %}
 {% endmacro %}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_namespace_packages, setup
 
 package_name = "dbt-mindsdb"
 # make sure this always matches dbt/adapters/mindsdb/__version__.py
-package_version = "1.0.2"
+package_version = "1.0.3"
 description = """The dbt adapter plugin for connecting to MindsDB"""
 with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()

--- a/tests/unit/test_mindsdb_adapter.py
+++ b/tests/unit/test_mindsdb_adapter.py
@@ -31,13 +31,13 @@ DBT_PROFILE_TMPL = '''
 demo:
   outputs:
     dev:
-      database: mindsdb
       host: 127.0.0.1
-      password: ''
       port: 47335
       type: mindsdb
+      database: mindsdb
+      schema: myproject
       username: mindsdb
-      schema: mindsdb
+      password: ''
   target: dev
 '''
 
@@ -145,10 +145,10 @@ class TestMindsDBAdapter(unittest.TestCase):
           select * from stores
         '''
 
-        expected1 = 'DROP PREDICTOR IF EXISTS new_predictor'
+        expected1 = 'DROP PREDICTOR IF EXISTS myproject.new_predictor'
 
         expected2 = '''
-        CREATE PREDICTOR new_predictor
+        CREATE PREDICTOR myproject.new_predictor
             FROM photorep  (
                   select * from stores
             ) PREDICT name  as name 
@@ -178,7 +178,7 @@ class TestMindsDBAdapter(unittest.TestCase):
         '''
 
         expected = '''
-            create or replace table `int1`.`schem`.`predict`
+            create or replace table `int1`.`predict`
             select * from (
                 select a, bc from ddd JOIN TEST_PREDICTOR_NAME where name > latest
             )
@@ -186,18 +186,18 @@ class TestMindsDBAdapter(unittest.TestCase):
 
         expected = self.sql_line_format(expected)
 
-        self.add_model('schem.predict', model)
+        self.add_model('predict', model)
         queries = self.get_dbt_queries()
 
         assert expected in queries
 
 
 
-    def test_create_database(self):
+    def test_create_integraton(self):
         model = '''
         {{
         config(
-          materialized='database',
+          materialized='integration',
           engine='trino',
           parameters={
             "user": "user",
@@ -214,17 +214,16 @@ class TestMindsDBAdapter(unittest.TestCase):
         }}
         '''
 
-        # expected1 = 'DROP DATABASE IF EXISTS new_database'
         expected1 = 'SHOW DATABASES'
 
         expected2 = '''
-        CREATE DATABASE new_database WITH ENGINE='trino',
+        CREATE DATABASE new_integration WITH ENGINE='trino',
         PARAMETERS={'user': 'user', 'auth': 'basic', 'http_scheme': 'https', 'port': 443, 'password': 'password', 'host': 'localhost', 'catalog': 'catalog', 'schema': 'schema', 'with': 'with (transactional = true)'}
         '''
 
         expected2 = self.sql_line_format(expected2)
 
-        self.add_model('new_database', model)
+        self.add_model('new_integration', model)
         queries = self.get_dbt_queries()
 
         # queries exist


### PR DESCRIPTION
We propose some enhances and changes in this PR
- add support to PROJECT (https://docs.mindsdb.com/sql/project). User could use `project` or `schema` in the dbt profile to specify the mindsDB PJ. One dbt project is supposed to be correspond to one mindsDB project. When the project (schema) does not exist, it will be created automatically.
- to reduce the confusion, change the `database` materialization to `integration` (no logic change)
- other changes:
   - increase version to 1.0.3
   - update unit test
   - update README