### PR TITLE
fix USING processing while create model(predictor)

### DIFF
--- a/dbt/include/mindsdb/macros/materialization/predictor.sql
+++ b/dbt/include/mindsdb/macros/materialization/predictor.sql
@@ -26,7 +26,7 @@
       {%- set keys = using.keys() -%}
 
       {% for key in keys|sort -%}
-         {{ using_list.append('{} = "{}"'.format(key, using[key]))  }}
+         {{ using_list.append('{} = {}'.format(key, using[key] | tojson) )  }}
       {%- endfor %}
 
       {% set using_str = using_list | join(',\n') %}


### PR DESCRIPTION
fix issue #28

customized USING like this should be ok:
```
/*
Using XGBoostMixer only
*/
{{
config(
  materialized='predictor',
  integration='mindsdb_attrition',
  predict='label',
  using={
    'model.module': "BestOf",
    'model.args' : {'submodels' : [{'module':'XGBoostMixer'}]}
  }
  )
}}
select * from train
```